### PR TITLE
Add multiplexed protocol support and ability to change serviceName

### DIFF
--- a/src/renderer/actions/settings.ts
+++ b/src/renderer/actions/settings.ts
@@ -5,6 +5,7 @@ import { parseAllThriftFilesFromDirectory } from '../thrift/parseAllThriftFilesF
 import { endpointSelector, selectedMethodSelector } from '../selectors/editor';
 import { stringIsAValidUrl } from '../utils/isValidUrl';
 
+export const SET_MULTIPLEXER_ENABLED = '@settings/setMutiplexerEnabled';
 export const SET_THRIFT_SOURCE_PATH = '@settings/setThriftSourcePath';
 export const SET_THRIFT_SOURCE_PATH_SUCCESS = '@settings/setThriftSourcePathSuccess';
 export const SET_THRIFT_SOURCE_PATH_ERROR = '@settings/setThriftSourcePathError';
@@ -17,6 +18,12 @@ export const SHOW_SETTINGS = '@settings/showSettings';
 export const HIDE_SETTINGS = '@settings/hideSettings';
 
 const settingsAC = {
+    setMultiplexerEnabled(value: boolean) {
+        return {
+            type: SET_MULTIPLEXER_ENABLED,
+            value
+        } as const;
+    },
     setThriftSourcePath(path: string) {
         return {
             type: SET_THRIFT_SOURCE_PATH,
@@ -106,6 +113,7 @@ export function setThriftSource(path: string): SettingsThunkAction {
     }
 }
 
+export const setMultiplexerEnabled = settingsAC.setMultiplexerEnabled;
 export const setProxyUrl = settingsAC.setProxyUrl;
 export const setProxyEnabled = settingsAC.setProxyEnabled;
 export const setRequestTimeout = settingsAC.setRequestTimeout;

--- a/src/renderer/components/Layout.tsx
+++ b/src/renderer/components/Layout.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { MethodsFilterContainer } from '../containers/MethodsFilterContainer';
 import { TabsContainer } from '../containers/TabsContainer';
 import { EndpointContainer } from '../containers/EndpointContainer';
+import { MultiplexerContainer } from '../containers/MultiplexerContainer';
 import { RequestEditorContainer } from '../containers/RequestEditorContainer';
 import { ResponseViewerContainer } from '../containers/ResponseContainer';
 
@@ -13,10 +14,11 @@ const StyledLayout = styled.div`
     grid-template-areas:
         "tabs tabs"
         "endpoint endpoint"
+        "multiplexer multiplexer"
         "browser request"
         "browser response";
     grid-template-columns: 280px minmax(0, 1fr);
-    grid-template-rows: auto auto 1fr 1fr;
+    grid-template-rows: auto auto auto 1fr 1fr;
 `;
 
 const StyledBrowser = styled(MethodsFilterContainer)`
@@ -43,6 +45,11 @@ const StyledEndpoint = styled(EndpointContainer)`
     background: #1a1a1a;
 `;
 
+const StyledMultiplexer = styled(MultiplexerContainer)`
+    grid-area: multiplexer;
+    background: #1a1a1a;
+`;
+
 const StyledResponseViewer = styled(ResponseViewerContainer)`
     grid-area: response;
     padding: 16px 0;
@@ -55,6 +62,7 @@ export const Layout = () => (
             <StyledTabs />
             <StyledRequestEditor />
             <StyledEndpoint />
+            <StyledMultiplexer />
             <StyledResponseViewer />
         </StyledLayout>
     </>

--- a/src/renderer/components/MultiplexerEditor.tsx
+++ b/src/renderer/components/MultiplexerEditor.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import styled from 'styled-components';
+import Input from 'arui-feather/input';
+import Label from 'arui-feather/label';
+import { SelectedMethod } from '../reducers/editorReducer';
+
+type Props = {
+    isMultiplexerEnabled: boolean;
+    onServiceNameChange: (value: SelectedMethod) => void;
+    selectedMethod: SelectedMethod | null;
+    className?: string;
+};
+
+const UrlBlock = styled.div`
+    display: flex;
+    align-items: center;
+    padding: 10px;
+`;
+
+const StyledInput = styled(Input)`
+    && .input__box {
+        background: rgba(255, 255, 255, .2);
+        border: 0;
+        border-radius: 4px;
+        height: 40px;
+        box-shadow: none;
+    }
+
+    && .input__control {
+        color: #ffffff;
+        height: 40px;
+        min-height: auto;
+        line-height: 40px;
+        padding: 0;
+        font-size: 13px;
+
+        ::placeholder {
+            color: #ffffff;
+            opacity: 0.4;
+        }
+    }
+`;
+
+const StyledLabel = styled(Label)`
+    && {
+        color: #ffffff;
+        margin-right: 10px;
+    }
+`;
+
+export const MultiplexerEditor = ({ className, isMultiplexerEnabled, onServiceNameChange, selectedMethod }: Props) => {
+    if (!isMultiplexerEnabled || !selectedMethod) return null;
+
+    const handleServiceNameChange = (value: string) => {
+        selectedMethod && onServiceNameChange({
+            ...selectedMethod,
+            modifiedServiceName: value,
+        });
+    };
+
+    const serviceName = selectedMethod.hasOwnProperty('modifiedServiceName')
+        ? selectedMethod.modifiedServiceName
+        : selectedMethod.serviceName;
+
+    return (
+        <UrlBlock className={ className }>
+            <StyledLabel size="s" isNoWrap={true}>Service Name:</StyledLabel>
+            <StyledInput
+                placeholder='Enter service name'
+                width='available'
+                view='filled'
+                value={ serviceName }
+                label='Service Name:'
+                onChange={ handleServiceNameChange }
+            />
+        </UrlBlock>
+    );
+};

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -7,6 +7,7 @@ import Spin from 'arui-feather/spin';
 import { Modal } from './Modal';
 
 type Props = {
+    isMultiplexerEnabled: boolean;
     isProxyEnabled: boolean;
     proxyUrl?: string;
     thriftSrcPath?: string;
@@ -14,6 +15,7 @@ type Props = {
     isThriftParsingInProgress: boolean;
     isOpened: boolean;
     onClose: () => void;
+    onIsMultiplexerEnabledChange: (value: boolean) => void;
     onIsProxyEnabledChange: (value: boolean) => void;
     onProxyUrlChange: (value: string) => void;
     onRequestTimeoutChange: (value: number) => void;
@@ -44,6 +46,13 @@ export const Settings = (props: Props) => {
             className={ props.className }
         >
             <StyledSettings>
+                <SettingsRow>
+                    <CheckBox
+                        text='Enable multiplexed protocol'
+                        checked={ props.isMultiplexerEnabled }
+                        onChange={ props.onIsMultiplexerEnabledChange }
+                    />
+                </SettingsRow>
                 <SettingsRow>
                     <CheckBox
                         text='Enable proxy'

--- a/src/renderer/containers/MultiplexerContainer.tsx
+++ b/src/renderer/containers/MultiplexerContainer.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import * as editorActions from '../actions/editor';
+import { MultiplexerEditor } from '../components/MultiplexerEditor';
+import { RootState } from '../reducers';
+import { bindActionCreators, Dispatch } from 'redux';
+import { selectedMethodSelector } from '../selectors/editor';
+import { multiplexerEnabledSelector } from '../selectors/settings';
+
+function mapStateToProps(state: RootState) {
+    return {
+        selectedMethod: selectedMethodSelector(state),
+        isMultiplexerEnabled: multiplexerEnabledSelector(state)
+    };
+}
+
+function mapDispatchToProps(dispatch: Dispatch) {
+    return bindActionCreators({
+        onServiceNameChange: editorActions.setServiceName
+    }, dispatch);
+}
+
+export const MultiplexerContainer = connect(mapStateToProps, mapDispatchToProps)(MultiplexerEditor);

--- a/src/renderer/containers/SettingsContainer.tsx
+++ b/src/renderer/containers/SettingsContainer.tsx
@@ -6,6 +6,7 @@ import { bindActionCreators, Dispatch } from 'redux';
 import { Settings } from '../components/Settings';
 import {
     isSettingsOpenedSelector,
+    multiplexerEnabledSelector,
     proxyEnabledSelector,
     proxyUrlSelector,
     requestTimeoutSelector,
@@ -16,6 +17,7 @@ import { isThriftParsingInProgressSelector } from '../selectors/services';
 
 function mapStateToProps(state: RootState) {
     return {
+        isMultiplexerEnabled: multiplexerEnabledSelector(state),
         isProxyEnabled: proxyEnabledSelector(state),
         proxyUrl: proxyUrlSelector(state),
         requestTimeout: requestTimeoutSelector(state),
@@ -29,6 +31,7 @@ function mapStateToProps(state: RootState) {
 function mapDispatchToProps(dispatch: Dispatch) {
     return bindActionCreators({
         onProxyUrlChange: settingsActions.setProxyUrl,
+        onIsMultiplexerEnabledChange: settingsActions.setMultiplexerEnabled,
         onIsProxyEnabledChange: settingsActions.setProxyEnabled,
         onRequestTimeoutChange: settingsActions.setRequestTimeout,
         onChangePathClick: settingsActions.showSelectThriftPathDialog,

--- a/src/renderer/reducers/editorReducer.ts
+++ b/src/renderer/reducers/editorReducer.ts
@@ -7,6 +7,7 @@ import {
     SELECT_SERVICE_AND_METHOD,
     SET_ENDPOINT,
     SET_REQUEST,
+    SET_SERVICE_NAME,
     SUBMIT_REQUEST,
     SUBMIT_REQUEST_ERROR,
     SUBMIT_REQUEST_SUCCESS,
@@ -16,6 +17,7 @@ import {
 export type SelectedMethod = {
     serviceName: string;
     methodName: string;
+    modifiedServiceName?: string;
 }
 
 export type SingleTabState = {
@@ -108,7 +110,8 @@ export function editorReducer(state: EditorReducerState = initialState, action: 
                         ...state.tabs[state.activeTabId],
                         selectedMethod: {
                             serviceName: action.serviceName,
-                            methodName: action.methodName
+                            methodName: action.methodName,
+                            modifiedServiceName: action.serviceName,
                         }
                     }
                 }
@@ -132,6 +135,19 @@ export function editorReducer(state: EditorReducerState = initialState, action: 
                     [state.activeTabId]: {
                         ...state.tabs[state.activeTabId],
                         request: action.value
+                    }
+                }
+            };
+        case SET_SERVICE_NAME:
+            return {
+                ...state,
+                tabs: {
+                    ...state.tabs,
+                    [state.activeTabId]: {
+                        ...state.tabs[state.activeTabId],
+                        selectedMethod: {
+                            ...action.selectedMethod
+                        }
                     }
                 }
             };
@@ -192,7 +208,8 @@ export function editorReducer(state: EditorReducerState = initialState, action: 
                         request: action.entry.request,
                         selectedMethod: {
                             serviceName: action.entry.serviceName,
-                            methodName: action.entry.methodName
+                            methodName: action.entry.methodName,
+                            modifiedServiceName: action.entry.serviceName
                         }
                     }
                 },

--- a/src/renderer/reducers/settingsReducer.ts
+++ b/src/renderer/reducers/settingsReducer.ts
@@ -1,19 +1,21 @@
 import {
-    SET_THRIFT_SOURCE_PATH_SUCCESS,
-    SET_PROXY_URL,
-    SET_PROXY_ENABLED,
-    SET_REQUEST_TIMEOUT,
-    SAVE_ENDPOINT_HISTORY,
-    SHOW_SETTINGS,
+    AllActions,
     HIDE_SETTINGS,
+    SAVE_ENDPOINT_HISTORY,
+    SET_MULTIPLEXER_ENABLED,
+    SET_PROXY_ENABLED,
+    SET_PROXY_URL,
+    SET_REQUEST_TIMEOUT,
+    SET_THRIFT_SOURCE_PATH_SUCCESS,
     SET_VERSION,
-    AllActions
+    SHOW_SETTINGS
 } from '../actions';
 
 export type SettingsState = {
     endpointsHistory: string[];
     thriftPath?: string;
     proxyUrl?: string;
+    isMultiplexerEnabled: boolean;
     isOpened: boolean;
     isProxyEnabled: boolean;
     requestTimeout: number;
@@ -21,6 +23,7 @@ export type SettingsState = {
 };
 
 export const defaultState: SettingsState = {
+    isMultiplexerEnabled: false,
     isOpened: false,
     isProxyEnabled: false,
     requestTimeout: 3000,
@@ -29,6 +32,11 @@ export const defaultState: SettingsState = {
 
 export function settingsReducer(state: SettingsState = defaultState, action: AllActions): SettingsState {
     switch (action.type) {
+        case SET_MULTIPLEXER_ENABLED:
+            return {
+                ...state,
+                isMultiplexerEnabled: action.value
+            };
         case SET_THRIFT_SOURCE_PATH_SUCCESS:
             return {
                 ...state,

--- a/src/renderer/selectors/editor.ts
+++ b/src/renderer/selectors/editor.ts
@@ -47,3 +47,7 @@ export const requestLoadingStateSelector = createSelector(
     activeTabSelector,
     tab => tab.requestLoadingState
 );
+export const modifiedServiceNameSelector = createSelector(
+    selectedMethodSelector,
+    selectedMethod => (selectedMethod && selectedMethod.modifiedServiceName) || ''
+);

--- a/src/renderer/selectors/settings.ts
+++ b/src/renderer/selectors/settings.ts
@@ -3,6 +3,11 @@ import { RootState } from '../reducers';
 
 export const settingsSelector = (state: RootState) => state.settings;
 
+export const multiplexerEnabledSelector = createSelector(
+    settingsSelector,
+    state => state.isMultiplexerEnabled
+);
+
 export const proxyUrlSelector = createSelector(
     settingsSelector,
     state => state.proxyUrl

--- a/src/renderer/thrift/performRequest.ts
+++ b/src/renderer/thrift/performRequest.ts
@@ -4,6 +4,7 @@ import { jsonNormalizerFilter } from '../utils/thriftJsonNormalizer';
 
 interface PerformRequestParameters {
     method: ParsedMethod;
+    messageName: string;
     endpoint: string;
     requestMessage: string;
     timeout: number;
@@ -11,12 +12,13 @@ interface PerformRequestParameters {
 }
 
 export async function performRequest(
-    { method, endpoint, requestMessage, timeout, proxy }: PerformRequestParameters
+    { method, messageName, endpoint, requestMessage, timeout, proxy }: PerformRequestParameters
 ) {
     const params = JSON.parse(requestMessage);
     const message = new method.ArgumentsMessage({
         id: 0,
-        body: new method.Arguments(params)
+        body: new method.Arguments(params),
+        name: messageName
     });
 
     const result = method.argumentsMessageRW.byteLength(message);


### PR DESCRIPTION
Resolves https://github.com/alfa-laboratory/thrift-api-ui/issues/10

This pull request adds Multiplexed protocol checkbox into Preferences modal, by enabling which thrift-api-ui will get an option to send requests to multiplexing Thrift server, by prepending the service name to the function name during function calls.

Also it adds support for service name aliases: when user selects some method, service name input appears under endpoint input, where user can change service name to an alias, which can be set during registering multiplexing processor in service (making service name declared in *.thrift invalid).