### PR TITLE
Fix TApplicationException handling on catching

### DIFF
--- a/src/renderer/thrift/performRequest.ts
+++ b/src/renderer/thrift/performRequest.ts
@@ -10,6 +10,8 @@ interface PerformRequestParameters {
     proxy?: string;
 }
 
+const stringify = (data: any) => JSON.stringify(data, jsonNormalizerFilter, 4);
+
 export async function performRequest(
     { method, endpoint, requestMessage, timeout, proxy }: PerformRequestParameters
 ) {
@@ -36,10 +38,10 @@ export async function performRequest(
     const res = await promise;
     const parsed = method.resultMessageRW.readFrom(res, 0);
     if (parsed.err) {
-        throw parsed.err;
+        throw stringify(parsed.err);
     }
     if (parsed.value.body.success) {
-        return JSON.stringify(parsed.value.body.success, jsonNormalizerFilter, 4);
+        return stringify(parsed.value.body.success);
     }
-    throw JSON.stringify(parsed.value.body.e || parsed.value.body, jsonNormalizerFilter, 4);
+    throw stringify(parsed.value.body.e || parsed.value.body);
 }


### PR DESCRIPTION
Resolves https://github.com/alfa-laboratory/thrift-api-ui/issues/9

Adds correct displaying of TApplicationException's: with current logic, `performRequest` can throw an TApplicationException error object, that will be stringified with .toString() method inside of SUBMIT_REQUEST_ERROR reducer, and this case results with `[object Object]` in output.