### PR TITLE
Add Content-Type header to each request

### DIFF
--- a/src/renderer/thrift/performRequest.ts
+++ b/src/renderer/thrift/performRequest.ts
@@ -29,6 +29,9 @@ export async function performRequest(
         uri: endpoint,
         body: buffer,
         encoding: null,
+        headers: {
+            'Content-Type': 'application/x-thrift',
+        },
         timeout,
         proxy
     });


### PR DESCRIPTION
Partially resolves https://github.com/alfa-laboratory/thrift-api-ui/issues/11

This pull request adds `'Content-Type': 'application/x-thrift'` header to each request.