### PR TITLE
fix(thrift): encode request with version 1 of protocol

### DIFF
--- a/src/renderer/thrift/performRequest.ts
+++ b/src/renderer/thrift/performRequest.ts
@@ -20,6 +20,7 @@ export async function performRequest(
     const message = new method.ArgumentsMessage({
         id: 0,
         body: new method.Arguments(params),
+        version: 1,
         name: messageName
     });
 


### PR DESCRIPTION
Используем strict-encodding для сообщений https://github.com/apache/thrift/blob/master/doc/specs/thrift-binary-protocol.md#message